### PR TITLE
Bump version: Sui and nixpkgs

### DIFF
--- a/README.org
+++ b/README.org
@@ -10,7 +10,7 @@ The example usage with flake.
   {
 
     inputs = {
-      nixpkgs = { url = "github:NixOS/nixpkgs/nixos-23.05"; };
+      nixpkgs = { url = "github:NixOS/nixpkgs/nixos-23.11"; };
       flake-utils = { url = "github:numtide/flake-utils"; };
       sui-overlay = { url = "github:doglooksgood/sui-overlay"; };
     };
@@ -18,13 +18,14 @@ The example usage with flake.
     outputs = { self, nixpkgs, flake-utils, sui-overlay }:
       flake-utils.lib.eachDefaultSystem (system:
         let
-          overlays = [ sui-overlay.overlays.default ];
+          overlays = [ sui-overlay.overlays.${system}.default ];
           pkgs = import nixpkgs { inherit system overlays; };
         in
           {
             devShell = pkgs.mkShell {
               buildInputs = with pkgs; [
                 sui-devnet # or sui-testnet, sui-mainnet
+                # other stuff
               ];
             };
           }

--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1688939073,
-        "narHash": "sha256-jYhYjeK5s6k8QS3i+ovq9VZqBJaWbxm7awTKNhHL9d0=",
+        "lastModified": 1706098335,
+        "narHash": "sha256-r3dWjT8P9/Ah5m5ul4WqIWD8muj5F+/gbCdjiNVBKmU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8df7a67abaf8aefc8a2839e0b48f92fdcf69a38b",
+        "rev": "a77ab169a83a4175169d78684ddd2e54486ac651",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.05",
+        "ref": "nixos-23.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Sui blockchain binaries";
 
   inputs = {
-    nixpkgs = { url = "github:NixOS/nixpkgs/nixos-23.05"; };
+    nixpkgs = { url = "github:NixOS/nixpkgs/nixos-23.11"; };
     flake-utils = { url = "github:numtide/flake-utils"; };
   };
 

--- a/overlays/sui-devnet.nix
+++ b/overlays/sui-devnet.nix
@@ -1,13 +1,23 @@
 pkgs: pkgs.stdenv.mkDerivation {
   name = "sui-devnet";
 
+  # Pass stripRoot=false; to fetchzip to assume flat list of files.
+  # devnet
+  # |--target/release/*
+  # |--external-crates/move/target/release/move-analyzer
   src = pkgs.fetchzip {
-    url = "https://github.com/MystenLabs/sui/releases/download/devnet-v1.7.0/sui-devnet-v1.7.0-ubuntu-x86_64.tgz";
-    sha256 = "sha256-/HwyetDYcxjdKgopdaC+ionsuW/Qd9I3VJOcNgz8TPs=";
+    stripRoot = false;
+    url = "https://github.com/MystenLabs/sui/releases/download/devnet-v1.17.0/sui-devnet-v1.17.0-ubuntu-x86_64.tgz";
+    sha256 = "sha256-pAduyLgqJINzW0nDky1zbo6ZaXcm7hAxOQ6+E2/q4LY=";
+
   };
 
   installPhase = ''
     mkdir -p $out/bin
-    cp $src/release/sui-ubuntu-x86_64 $out/bin/sui
+    cp $src/external-crates/move/target/release/move-analyzer-ubuntu-x86_64 $out/bin/move-analyzer
+    cd $src/target/release
+    for b in *; do
+        cp ''${b} $out/bin/''${b%-ubuntu-x86_64}
+    done
   '';
 }

--- a/overlays/sui-mainnet.nix
+++ b/overlays/sui-mainnet.nix
@@ -2,12 +2,15 @@ pkgs: pkgs.stdenv.mkDerivation {
   name = "sui-mainnet";
 
   src = pkgs.fetchzip {
-    url = "https://github.com/MystenLabs/sui/releases/download/mainnet-v1.6.3/sui-mainnet-v1.6.3-ubuntu-x86_64.tgz";
-    sha256 = "sha256-jCpQUtEq8ssh0XP+bRBECmHGv9SGAJSigHdZAwX3C6w=";
+    url = "https://github.com/MystenLabs/sui/releases/download/mainnet-v1.16.2/sui-mainnet-v1.16.2-ubuntu-x86_64.tgz";
+    sha256 = "sha256-I8hV04zJQ1/c5aNc3MdOC0i4t5DQgod3rOdv4PosEL4=";
   };
 
   installPhase = ''
     mkdir -p $out/bin
-    cp $src/release/sui-ubuntu-x86_64 $out/bin/sui
+    cd $src/target/release
+    for b in *; do
+        cp ''${b} $out/bin/''${b%-ubuntu-x86_64}
+    done
  '';
 }

--- a/overlays/sui-testnet.nix
+++ b/overlays/sui-testnet.nix
@@ -2,12 +2,17 @@ pkgs: pkgs.stdenv.mkDerivation {
   name = "sui-testnet";
 
   src = pkgs.fetchzip {
-    url = "https://github.com/MystenLabs/sui/releases/download/testnet-v1.7.0/sui-testnet-v1.7.0-ubuntu-x86_64.tgz";
-    sha256 = "sha256-agJl/rml/oLeEBn7BBmnhGKZFMxpTP3qedmaqrpATmk=";
+    stripRoot = false;
+    url = "https://github.com/MystenLabs/sui/releases/download/testnet-v1.17.0/sui-testnet-v1.17.0-ubuntu-x86_64.tgz";
+    sha256 = "sha256-qCOpM//qRbjZBkJpoNEfyp44YPlQ3wlE5qgRNIGwk6E=";
   };
 
   installPhase = ''
     mkdir -p $out/bin
-    cp $src/release/sui-ubuntu-x86_64 $out/bin/sui
+    cp $src/external-crates/move/target/release/move-analyzer-ubuntu-x86_64 $out/bin/move-analyzer
+    cd $src/target/release
+    for b in *; do
+        cp ''${b} $out/bin/''${b%-ubuntu-x86_64}
+    done
   '';
 }


### PR DESCRIPTION
* nixpkgs to 23.11
* Sui devnet and testnet to v17
* Sui mainnet to v16
* Include other binaries such as faucet and move-analyzer
* Fix README Usage